### PR TITLE
Fix query for San Francisco

### DIFF
--- a/src/main/java/com/clapinig/bayareacovidtracker/server/repositories/DailyReportRepository.java
+++ b/src/main/java/com/clapinig/bayareacovidtracker/server/repositories/DailyReportRepository.java
@@ -14,7 +14,7 @@ public interface DailyReportRepository extends CrudRepository<DailyReport, Integ
             "where Province_State=\"California\"" +
             " AND Admin2=\"Alameda\"" +
             " OR Admin2=\"Contra Costa\" OR Admin2=\"San Mateo\" OR Admin2=\"Santa Clara\"" +
-            " OR Admin2=\" San Francisco\" OR Admin2=\"Marin\" OR Admin2=\"Solano\" OR Admin2=\"Napa\"" +
+            " OR Admin2=\"San Francisco\" OR Admin2=\"Marin\" OR Admin2=\"Solano\" OR Admin2=\"Napa\"" +
             " OR Admin2=\"Sonoma\"",
             nativeQuery = true
     )


### PR DESCRIPTION
Removed extra space in the San Francisco query that was not allowing results for San Francisco to show