### PR TITLE
Change models to reflect data required by ReactMapGL/Mapbox

### DIFF
--- a/src/main/java/com/clapinig/bayareacovidtracker/server/controllers/DailyReportController.java
+++ b/src/main/java/com/clapinig/bayareacovidtracker/server/controllers/DailyReportController.java
@@ -22,7 +22,7 @@ public class DailyReportController {
 
         try {
             res.put("success", true);
-            res.put("dailyReport", dailyReportService.getDailyReport());
+            res.put("reports", dailyReportService.getDailyReport());
         } catch (Exception e) {
             res.put("success", false);
             res.put("err", e.getMessage());

--- a/src/main/java/com/clapinig/bayareacovidtracker/server/models/County.java
+++ b/src/main/java/com/clapinig/bayareacovidtracker/server/models/County.java
@@ -1,26 +1,24 @@
 package com.clapinig.bayareacovidtracker.server.models;
 
+// Purpose: Create properties needed for the "properties" property in the Report model
+// Needs to reflect data structure required by ReactMapGL component on client
 public class County {
     private Integer id;
     private String county;
     private String state;
     private String country;
     private String lastUpdate;
-    private Double lat;
-    private Double lon;
     private Integer confirmed;
     private Integer deaths;
 
     public County() {}
 
-    public County(Integer id, String county, String state, String country, String lastUpdate, Double lat, Double lon, Integer confirmed, Integer deaths) {
+    public County(Integer id, String county, String state, String country, String lastUpdate, Integer confirmed, Integer deaths) {
         this.id = id;
         this.county = county;
         this.state = state;
         this.country = country;
         this.lastUpdate = lastUpdate;
-        this.lat = lat;
-        this.lon = lon;
         this.confirmed = confirmed;
         this.deaths = deaths;
     }
@@ -63,22 +61,6 @@ public class County {
 
     public void setLastUpdate(String lastUpdate) {
         this.lastUpdate = lastUpdate;
-    }
-
-    public Double getLat() {
-        return lat;
-    }
-
-    public void setLat(Double lat) {
-        this.lat = lat;
-    }
-
-    public Double getLon() {
-        return lon;
-    }
-
-    public void setLon(Double lon) {
-        this.lon = lon;
     }
 
     public Integer getConfirmed() {

--- a/src/main/java/com/clapinig/bayareacovidtracker/server/models/DailyReport.java
+++ b/src/main/java/com/clapinig/bayareacovidtracker/server/models/DailyReport.java
@@ -3,6 +3,7 @@ package com.clapinig.bayareacovidtracker.server.models;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
+// Strucutre the data returned by the MySQL query
 @Entity
 public class DailyReport {
     @Id

--- a/src/main/java/com/clapinig/bayareacovidtracker/server/models/Point.java
+++ b/src/main/java/com/clapinig/bayareacovidtracker/server/models/Point.java
@@ -1,0 +1,33 @@
+package com.clapinig.bayareacovidtracker.server.models;
+
+import java.util.List;
+
+// Purpose: Create properties needed for the "geometry" property in the Report model
+// Needs to reflect data structure required by ReactMapGL component on client
+public class Point {
+    private String type;
+    private List<Double> coordinates;
+
+    public Point() {}
+
+    public Point(List<Double> coordinates) {
+        this.type = "Point";
+        this.coordinates = coordinates;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public List<Double> getCoordinates() {
+        return coordinates;
+    }
+
+    public void setCoordinates(List<Double> coordinates) {
+        this.coordinates = coordinates;
+    }
+}

--- a/src/main/java/com/clapinig/bayareacovidtracker/server/models/Report.java
+++ b/src/main/java/com/clapinig/bayareacovidtracker/server/models/Report.java
@@ -1,0 +1,61 @@
+package com.clapinig.bayareacovidtracker.server.models;
+
+/*
+Report class is meant to reflect the data structure needed to display data on ReactMapGL component on the client side
+Example JSON repsonse made from this model:
+{
+    "type": "Feature",
+    "properties": {
+        "id": 0,
+        "county": "Example County",
+        "state": "California",
+        "country": "US",
+        "confirmed": 50,
+        "deaths": 0
+    },
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            -122.333,
+            37.445
+        ]
+    }
+}
+ */
+public class Report {
+    private String type;
+    private County properties;
+    private Point geometry;
+
+    public Report() {}
+
+    public Report(County properties, Point geometry) {
+        this.type = "Feature";
+        this.properties = properties;
+        this.geometry = geometry;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public County getProperties() {
+        return properties;
+    }
+
+    public void setProperties(County properties) {
+        this.properties = properties;
+    }
+
+    public Point getGeometry() {
+        return geometry;
+    }
+
+    public void setGeometry(Point geometry) {
+        this.geometry = geometry;
+    }
+}

--- a/src/main/java/com/clapinig/bayareacovidtracker/server/services/DailyReportService.java
+++ b/src/main/java/com/clapinig/bayareacovidtracker/server/services/DailyReportService.java
@@ -1,9 +1,9 @@
 package com.clapinig.bayareacovidtracker.server.services;
 
-import java.util.HashMap;
+import java.util.List;
 
-import com.clapinig.bayareacovidtracker.server.models.County;
+import com.clapinig.bayareacovidtracker.server.models.Report;
 
 public interface DailyReportService {
-    HashMap<String, County> getDailyReport();
+    List<Report> getDailyReport();
 }

--- a/src/main/java/com/clapinig/bayareacovidtracker/server/services/DailyReportServiceImpl.java
+++ b/src/main/java/com/clapinig/bayareacovidtracker/server/services/DailyReportServiceImpl.java
@@ -1,7 +1,7 @@
 package com.clapinig.bayareacovidtracker.server.services;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.HashMap;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -14,18 +14,27 @@ public class DailyReportServiceImpl implements DailyReportService {
     @Autowired
     DailyReportRepository dailyReportRepository;
 
-    public HashMap<String, County> getDailyReport() {
+    public List<Report> getDailyReport() {
         List<DailyReport> dailyReportList = dailyReportRepository.getDailyReport();
-        HashMap<String, County> dailyReports = new HashMap<>();
+        List<Report> reports = new ArrayList<>();
 
-        for (DailyReport report : dailyReportList) {
-            County county = new County(report.getFIPS(), report.getAdmin2(), report.getProvince_State(),
-                    report.getCountry_Region(), report.getLast_Update(), report.getLat(), report.getLong_(),
-                    report.getConfirmed(), report.getDeaths());
+        for (DailyReport dr : dailyReportList) {
+            // county represents the properties instance variable of Report model
+            County county = new County(dr.getFIPS(), dr.getAdmin2(), dr.getProvince_State(),
+                    dr.getCountry_Region(), dr.getLast_Update(), dr.getConfirmed(), dr.getDeaths());
 
-            dailyReports.put(county.getCounty(), county);
+            // point represents the geometry instance variable of Report model
+            Point point = new Point(new ArrayList<Double>() {
+                {
+                    add(dr.getLong_());
+                    add(dr.getLat());
+                }
+            });
+            Report report = new Report(county, point);
+
+            reports.add(report);
         }
 
-        return dailyReports;
+        return reports;
     }
 }

--- a/src/test/java/com/clapinig/bayareacovidtracker/server/services/DailyReportServiceTest.java
+++ b/src/test/java/com/clapinig/bayareacovidtracker/server/services/DailyReportServiceTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 
-import com.clapinig.bayareacovidtracker.server.models.County;
+import com.clapinig.bayareacovidtracker.server.models.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
@@ -21,20 +21,27 @@ public class DailyReportServiceTest {
     private DailyReportService dailyReportService = new DailyReportServiceImpl();
 
     // Initialize dummy report
-    HashMap<String, County> dummyReport = new HashMap<>();
+    List<Report> dummyReports = new ArrayList<>();
 
     @BeforeEach
     void setMockOutput() {
         // Setup dummy data for test
-        County dummyCounty = new County(5555, "Alameda", "California", "US", "2020-03-28 23:05:37", 37.6463, -121.893, 200, 4);
-        dummyReport.put(dummyCounty.getCounty(), dummyCounty);
+        County dummyCounty = new County(5555, "Alameda", "California", "US", "2020-03-28 23:05:37", 200, 4);
+        Point dummyPoint = new Point(new ArrayList<Double>() {
+            {
+                add(-121.697);
+                add(37.231);
+            }
+        });
+        Report dummyReport = new Report(dummyCounty, dummyPoint);
+        dummyReports.add(dummyReport);
 
-        when(dailyReportService.getDailyReport()).thenReturn(dummyReport);
+        when(dailyReportService.getDailyReport()).thenReturn(dummyReports);
     }
 
     @DisplayName("fetch daily reports with getDailyReport")
     @Test
     void testGetDailyReport() {
-        assertEquals(dummyReport, dailyReportService.getDailyReport());
+        assertEquals(dummyReports, dailyReportService.getDailyReport());
     }
 }


### PR DESCRIPTION
Mapbox requires each report to have data structured a certain way to display it on the map the way it's intended. Here is the list of changes and additions:
* Added Point model to reflect the "geometry" property required by Mapbox
* Added Report model that will contain a County and Point object to reflect the properties and geometry properties
* Changed the County model by removing lat and lon instance variables which are now used in the Point model
* Changed the data type returned by `getDailyReport()`. Mapbox requires the data to be returned as a list containing the Report objects
* Changed service tests to reflect these changes